### PR TITLE
CustomFunction.Create for zero parameter function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Changelog
 
-## [1.2.0] - 2025-09-28
+## [1.2.0] - 2025-09-29
 
 ### Added
 - **VariableId struct**: Strongly-typed variable identifier that replaces direct `uint` usage
   - Provides implicit conversions to/from `uint` and `string` for backwards compatibility
   - Maintains internal unique identifier mapping through extension methods
   - Improves type safety and encapsulates identifier management
+- Support for `CustomFunction.Create` with zero-parameter functions that have return values (`Func<TResult>`)
 
 ### Changed
 - **BREAKING CHANGE**: `IVariableContainer.TryGetValue()` now takes `VariableId` instead of `uint`

--- a/EpsilonScript.Tests/AST/AST_Function.cs
+++ b/EpsilonScript.Tests/AST/AST_Function.cs
@@ -292,6 +292,202 @@ namespace EpsilonScript.Tests.AST
       Assert.Equal(6, node.IntegerValue);
     }
 
+    [Fact]
+    public void AST_Function_WithZeroParameterIntegerFunction_ReturnsCorrectValue()
+    {
+      var functions = new Dictionary<VariableId, CustomFunctionOverload>();
+      var functionName = "getAnswer";
+      var functionId = (VariableId)functionName;
+
+      var customFunction = CustomFunction.Create(functionName, () => 42);
+      var overload = new CustomFunctionOverload(customFunction);
+      functions[functionId] = overload;
+
+      var node = new FunctionNode();
+      var nullNode = new NullNode();
+      nullNode.Build(new Stack<Node>(), new Element(new Token(), ElementType.None), Compiler.Options.None, null, null);
+      var rpn = CreateStack(nullNode);
+      var token = new Token(functionName, TokenType.Identifier);
+      var element = new Element(token, ElementType.Function);
+
+      node.Build(rpn, element, Compiler.Options.None, null, functions);
+      node.Execute(null);
+
+      Assert.Equal(ValueType.Integer, node.ValueType);
+      Assert.Equal(42, node.IntegerValue);
+      Assert.Equal(42.0f, node.FloatValue);
+      Assert.True(node.BooleanValue);
+    }
+
+    [Fact]
+    public void AST_Function_WithZeroParameterFloatFunction_ReturnsCorrectValue()
+    {
+      var functions = new Dictionary<VariableId, CustomFunctionOverload>();
+      var functionName = "getPi";
+      var functionId = (VariableId)functionName;
+
+      var customFunction = CustomFunction.Create(functionName, () => 3.14159f);
+      var overload = new CustomFunctionOverload(customFunction);
+      functions[functionId] = overload;
+
+      var node = new FunctionNode();
+      var nullNode = new NullNode();
+      nullNode.Build(new Stack<Node>(), new Element(new Token(), ElementType.None), Compiler.Options.None, null, null);
+      var rpn = CreateStack(nullNode);
+      var token = new Token(functionName, TokenType.Identifier);
+      var element = new Element(token, ElementType.Function);
+
+      node.Build(rpn, element, Compiler.Options.None, null, functions);
+      node.Execute(null);
+
+      Assert.Equal(ValueType.Float, node.ValueType);
+      Assert.Equal(3.14159f, node.FloatValue, 5);
+      Assert.Equal(3, node.IntegerValue);
+      Assert.True(node.BooleanValue);
+    }
+
+    [Fact]
+    public void AST_Function_WithZeroParameterBooleanFunction_ReturnsCorrectValue()
+    {
+      var functions = new Dictionary<VariableId, CustomFunctionOverload>();
+      var functionName = "isReady";
+      var functionId = (VariableId)functionName;
+
+      var customFunction = CustomFunction.Create(functionName, () => true);
+      var overload = new CustomFunctionOverload(customFunction);
+      functions[functionId] = overload;
+
+      var node = new FunctionNode();
+      var nullNode = new NullNode();
+      nullNode.Build(new Stack<Node>(), new Element(new Token(), ElementType.None), Compiler.Options.None, null, null);
+      var rpn = CreateStack(nullNode);
+      var token = new Token(functionName, TokenType.Identifier);
+      var element = new Element(token, ElementType.Function);
+
+      node.Build(rpn, element, Compiler.Options.None, null, functions);
+      node.Execute(null);
+
+      Assert.Equal(ValueType.Boolean, node.ValueType);
+      Assert.True(node.BooleanValue);
+      Assert.Equal(1, node.IntegerValue);
+      Assert.Equal(1.0f, node.FloatValue);
+    }
+
+    [Fact]
+    public void AST_Function_WithZeroParameterStringFunction_ReturnsCorrectValue()
+    {
+      var functions = new Dictionary<VariableId, CustomFunctionOverload>();
+      var functionName = "getVersion";
+      var functionId = (VariableId)functionName;
+
+      var customFunction = CustomFunction.Create(functionName, () => "v1.2.0");
+      var overload = new CustomFunctionOverload(customFunction);
+      functions[functionId] = overload;
+
+      var node = new FunctionNode();
+      var nullNode = new NullNode();
+      nullNode.Build(new Stack<Node>(), new Element(new Token(), ElementType.None), Compiler.Options.None, null, null);
+      var rpn = CreateStack(nullNode);
+      var token = new Token(functionName, TokenType.Identifier);
+      var element = new Element(token, ElementType.Function);
+
+      node.Build(rpn, element, Compiler.Options.None, null, functions);
+      node.Execute(null);
+
+      Assert.Equal(ValueType.String, node.ValueType);
+      Assert.Equal("v1.2.0", node.StringValue);
+    }
+
+    [Fact]
+    public void AST_Function_WithZeroParameterConstantFunction_IsConstant()
+    {
+      var functions = new Dictionary<VariableId, CustomFunctionOverload>();
+      var functionName = "getConstant";
+      var functionId = (VariableId)functionName;
+
+      var customFunction = CustomFunction.Create(functionName, () => 100, true);
+      var overload = new CustomFunctionOverload(customFunction);
+      functions[functionId] = overload;
+
+      var node = new FunctionNode();
+      var nullNode = new NullNode();
+      nullNode.Build(new Stack<Node>(), new Element(new Token(), ElementType.None), Compiler.Options.None, null, null);
+      var rpn = CreateStack(nullNode);
+      var token = new Token(functionName, TokenType.Identifier);
+      var element = new Element(token, ElementType.Function);
+
+      node.Build(rpn, element, Compiler.Options.None, null, functions);
+      node.Execute(null);
+
+      Assert.True(node.IsConstant);
+      Assert.Equal(100, node.IntegerValue);
+    }
+
+    [Fact]
+    public void AST_Function_WithZeroParameterNonConstantFunction_IsNotConstant()
+    {
+      var functions = new Dictionary<VariableId, CustomFunctionOverload>();
+      var functionName = "getTimestamp";
+      var functionId = (VariableId)functionName;
+
+      var customFunction = CustomFunction.Create(functionName, () => DateTime.Now.Millisecond, false);
+      var overload = new CustomFunctionOverload(customFunction);
+      functions[functionId] = overload;
+
+      var node = new FunctionNode();
+      var nullNode = new NullNode();
+      nullNode.Build(new Stack<Node>(), new Element(new Token(), ElementType.None), Compiler.Options.None, null, null);
+      var rpn = CreateStack(nullNode);
+      var token = new Token(functionName, TokenType.Identifier);
+      var element = new Element(token, ElementType.Function);
+
+      node.Build(rpn, element, Compiler.Options.None, null, functions);
+
+      Assert.False(node.IsConstant);
+    }
+
+
+    [Fact]
+    public void AST_Function_WithZeroParameterFunctionMixedWithParameterizedFunction_WorksCorrectly()
+    {
+      var functions = new Dictionary<VariableId, CustomFunctionOverload>();
+
+      // Add a zero-parameter function
+      var zeroParamName = "getZero";
+      var zeroParamId = (VariableId)zeroParamName;
+      var zeroParamFunction = CustomFunction.Create(zeroParamName, () => 0);
+      var zeroParamOverload = new CustomFunctionOverload(zeroParamFunction);
+      functions[zeroParamId] = zeroParamOverload;
+
+      // Add a one-parameter function with the same name (overload)
+      var oneParamFunction = CustomFunction.Create(zeroParamName, (int x) => x + 100);
+      zeroParamOverload.Add(oneParamFunction);
+
+      // Test zero-parameter call
+      var node1 = new FunctionNode();
+      var nullNode1 = new NullNode();
+      nullNode1.Build(new Stack<Node>(), new Element(new Token(), ElementType.None), Compiler.Options.None, null, null);
+      var rpn1 = CreateStack(nullNode1);
+      var token1 = new Token(zeroParamName, TokenType.Identifier);
+      var element1 = new Element(token1, ElementType.Function);
+
+      node1.Build(rpn1, element1, Compiler.Options.None, null, functions);
+      node1.Execute(null);
+
+      Assert.Equal(0, node1.IntegerValue); // Zero-parameter version
+
+      // Test one-parameter call
+      var node2 = new FunctionNode();
+      var rpn2 = CreateStack(new FakeIntegerNode(5)); // One parameter
+      var token2 = new Token(zeroParamName, TokenType.Identifier);
+      var element2 = new Element(token2, ElementType.Function);
+
+      node2.Build(rpn2, element2, Compiler.Options.None, null, functions);
+      node2.Execute(null);
+
+      Assert.Equal(105, node2.IntegerValue); // One-parameter version (5 + 100)
+    }
+
     // Helper class for testing non-constant parameters
     private class TestVariableNode : Node
     {

--- a/EpsilonScript.Tests/ScriptSystem/ScriptFunctionTests.cs
+++ b/EpsilonScript.Tests/ScriptSystem/ScriptFunctionTests.cs
@@ -181,5 +181,52 @@ namespace EpsilonScript.Tests.ScriptSystem
       AssertNearlyEqual(15.0f, script.FloatValue);
       Assert.Equal(1, counter.Count);
     }
+
+    [Fact]
+    public void ZeroParameterFunction_WithParentheses_ExecutesCorrectly()
+    {
+      var getAnswer = CustomFunction.Create("getAnswer", () => 42);
+      var getPi = CustomFunction.Create("getPi", () => 3.14159f);
+      var getGreeting = CustomFunction.Create("getGreeting", () => "Hello");
+      var isReady = CustomFunction.Create("isReady", () => true);
+
+      // Test integer return
+      var intResult = CompileAndExecute("getAnswer()", Compiler.Options.None, null, null, getAnswer);
+      Assert.Equal(Type.Integer, intResult.ValueType);
+      Assert.Equal(42, intResult.IntegerValue);
+
+      // Test float return
+      var floatResult = CompileAndExecute("getPi()", Compiler.Options.None, null, null, getPi);
+      Assert.Equal(Type.Float, floatResult.ValueType);
+      AssertNearlyEqual(3.14159f, floatResult.FloatValue);
+
+      // Test string return
+      var stringResult = CompileAndExecute("getGreeting()", Compiler.Options.None, null, null, getGreeting);
+      Assert.Equal(Type.String, stringResult.ValueType);
+      Assert.Equal("Hello", stringResult.StringValue);
+
+      // Test boolean return
+      var boolResult = CompileAndExecute("isReady()", Compiler.Options.None, null, null, isReady);
+      Assert.Equal(Type.Boolean, boolResult.ValueType);
+      Assert.True(boolResult.BooleanValue);
+    }
+
+    [Fact]
+    public void ZeroParameterFunction_InExpression_ExecutesCorrectly()
+    {
+      var getTwo = CustomFunction.Create("getTwo", () => 2);
+      var getThree = CustomFunction.Create("getThree", () => 3);
+
+      // Test zero-parameter functions in arithmetic expressions
+      var result1 = CompileAndExecute("getTwo() + getThree()", Compiler.Options.None, null, null, getTwo, getThree);
+      Assert.Equal(Type.Integer, result1.ValueType);
+      Assert.Equal(5, result1.IntegerValue);
+
+      // Test zero-parameter function with regular parameter function
+      var doubleFunc = CustomFunction.Create("double", (int x) => x * 2);
+      var result2 = CompileAndExecute("double(getTwo())", Compiler.Options.None, null, null, getTwo, doubleFunc);
+      Assert.Equal(Type.Integer, result2.ValueType);
+      Assert.Equal(4, result2.IntegerValue);
+    }
   }
 }

--- a/EpsilonScript/AST/FunctionNode.cs
+++ b/EpsilonScript/AST/FunctionNode.cs
@@ -63,6 +63,7 @@ namespace EpsilonScript.AST
           _parameterTypes = new Type[_parameters.Count];
           break;
         case ValueType.Null:
+          _parameters = new List<Node>();
           _parameterTypes = Array.Empty<Type>();
           break;
         default:
@@ -134,6 +135,7 @@ namespace EpsilonScript.AST
         case ValueType.Float:
           FloatValue = function.ExecuteFloat(_parameters);
           IntegerValue = (int)FloatValue;
+          BooleanValue = FloatValue != 0.0f;
           break;
         case ValueType.String:
           StringValue = function.ExecuteString(_parameters);

--- a/EpsilonScript/Function/CustomFunction.cs
+++ b/EpsilonScript/Function/CustomFunction.cs
@@ -64,6 +64,11 @@ namespace EpsilonScript.Function
       throw new InvalidOperationException("Function does not return boolean");
     }
 
+    public static CustomFunction Create<TResult>(string name, Func<TResult> func, bool isConstant = false)
+    {
+      return new CustomFunction<TResult>(name, func, isConstant);
+    }
+
     public static CustomFunction Create<T1, TResult>(string name, Func<T1, TResult> func, bool isConstant = false)
     {
       return new CustomFunction<T1, TResult>(name, func, isConstant);
@@ -91,6 +96,47 @@ namespace EpsilonScript.Function
       Func<T1, T2, T3, T4, T5, TResult> func, bool isConstant = false)
     {
       return new CustomFunction<T1, T2, T3, T4, T5, TResult>(name, func, isConstant);
+    }
+  }
+
+  public sealed class CustomFunction<TResult> : CustomFunction
+  {
+    private readonly Func<TResult> _func;
+
+    public CustomFunction(string name, Func<TResult> func, bool isConstant = false)
+      : base(name, isConstant, Array.Empty<ScriptType>(), TypeTraits<TResult>.ScriptType)
+    {
+      _func = func ?? throw new ArgumentNullException(nameof(func));
+    }
+
+    private TResult Invoke(List<Node> parameters)
+    {
+      EnsureParameterCount(parameters);
+      return _func();
+    }
+
+    public override int ExecuteInt(List<Node> parameters)
+    {
+      EnsureReturnType(Type.Integer);
+      return TypeTraits<TResult>.ToInt(Invoke(parameters));
+    }
+
+    public override float ExecuteFloat(List<Node> parameters)
+    {
+      EnsureReturnType(Type.Float);
+      return TypeTraits<TResult>.ToFloat(Invoke(parameters));
+    }
+
+    public override string ExecuteString(List<Node> parameters)
+    {
+      EnsureReturnType(Type.String);
+      return TypeTraits<TResult>.ToStringValue(Invoke(parameters));
+    }
+
+    public override bool ExecuteBool(List<Node> parameters)
+    {
+      EnsureReturnType(Type.Boolean);
+      return TypeTraits<TResult>.ToBool(Invoke(parameters));
     }
   }
 


### PR DESCRIPTION
Support for `CustomFunction.Create` with zero-parameter functions that have return values (`Func<TResult>`)