### PR TITLE
Allow period character in identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.2.0] - 2025-09-29
 
 ### Added
+- **Period characters in identifiers**: Variable names and function names can now contain periods (e.g., `user.name`, `math.square()`)
 - **VariableId struct**: Strongly-typed variable identifier that replaces direct `uint` usage
   - Provides implicit conversions to/from `uint` and `string` for backwards compatibility
   - Maintains internal unique identifier mapping through extension methods

--- a/EpsilonScript.Tests/Lexer/Lexer_Identifier.cs
+++ b/EpsilonScript.Tests/Lexer/Lexer_Identifier.cs
@@ -62,6 +62,31 @@ namespace EpsilonScript.Tests.Lexer
             "_hello10",
             new Token("_hello10", TokenType.Identifier)
           },
+          new object[]
+          {
+            "variable.name",
+            new Token("variable.name", TokenType.Identifier)
+          },
+          new object[]
+          {
+            "my.function.call",
+            new Token("my.function.call", TokenType.Identifier)
+          },
+          new object[]
+          {
+            "obj.prop.value",
+            new Token("obj.prop.value", TokenType.Identifier)
+          },
+          new object[]
+          {
+            "_internal.helper.func",
+            new Token("_internal.helper.func", TokenType.Identifier)
+          },
+          new object[]
+          {
+            "test123.var456.item",
+            new Token("test123.var456.item", TokenType.Identifier)
+          },
         };
       }
     }

--- a/EpsilonScript.Tests/ScriptSystem/ScriptFunctionTests.cs
+++ b/EpsilonScript.Tests/ScriptSystem/ScriptFunctionTests.cs
@@ -334,5 +334,35 @@ namespace EpsilonScript.Tests.ScriptSystem
       afterScript.Execute();
       Assert.Equal("TEST", afterScript.StringValue);
     }
+
+    [Fact]
+    public void PeriodInFunctionNames_EvaluatesCorrectly()
+    {
+      var utilDouble = CustomFunction.Create("util.double", (int x) => x * 2);
+      var stringConcat = CustomFunction.Create("string.concat", (string a, string b) => a + b);
+
+      var result1 = CompileAndExecute("util.double(5)", extraFunctions: utilDouble);
+      Assert.Equal(Type.Integer, result1.ValueType);
+      Assert.Equal(10, result1.IntegerValue);
+
+      var result2 = CompileAndExecute("string.concat(\"Hello\", \" World\")", extraFunctions: stringConcat);
+      Assert.Equal(Type.String, result2.ValueType);
+      Assert.Equal("Hello World", result2.StringValue);
+    }
+
+    [Fact]
+    public void ComplexPeriodIdentifiers_WorkCorrectly()
+    {
+      var mathSquare = CustomFunction.Create("math.square", (float x) => x * x);
+      var variables = Variables()
+        .WithFloat("math.pi.value", 3.14159f)
+        .Build();
+
+      var result = CompileAndExecute("math.square(math.pi.value)", variables: variables, extraFunctions: mathSquare);
+
+      Assert.Equal(Type.Float, result.ValueType);
+      // Calculate the expected value precisely: 3.14159f * 3.14159f = 9.869589f
+      AssertNearlyEqual(9.869589f, result.FloatValue);
+    }
   }
 }

--- a/EpsilonScript.Tests/ScriptSystem/ScriptVariableTests.cs
+++ b/EpsilonScript.Tests/ScriptSystem/ScriptVariableTests.cs
@@ -159,5 +159,58 @@ namespace EpsilonScript.Tests.ScriptSystem
       Assert.Equal(Type.String, variable.Type);
       Assert.Equal("42", variable.StringValue);
     }
+
+    [Fact]
+    public void PeriodInStringVariableNames_EvaluatesCorrectly()
+    {
+      var variables = Variables()
+        .WithString("user.name", "John")
+        .Build();
+
+      var result = CompileAndExecute("user.name", variables: variables);
+
+      Assert.Equal(Type.String, result.ValueType);
+      Assert.Equal("John", result.StringValue);
+    }
+
+    [Fact]
+    public void PeriodInIntegerVariableNames_EvaluatesCorrectly()
+    {
+      var variables = Variables()
+        .WithInteger("config.server.port", 8080)
+        .Build();
+
+      var result = CompileAndExecute("config.server.port", variables: variables);
+
+      Assert.Equal(Type.Integer, result.ValueType);
+      Assert.Equal(8080, result.IntegerValue);
+    }
+
+    [Fact]
+    public void PeriodInFloatVariableNames_EvaluatesCorrectly()
+    {
+      var variables = Variables()
+        .WithFloat("math.pi.value", 3.14159f)
+        .Build();
+
+      var result = CompileAndExecute("math.pi.value", variables: variables);
+
+      Assert.Equal(Type.Float, result.ValueType);
+      AssertNearlyEqual(3.14159f, result.FloatValue);
+    }
+
+    [Fact]
+    public void PeriodInVariableAssignment_WorksCorrectly()
+    {
+      var variables = Variables()
+        .WithString("user.name", "John")
+        .Build();
+
+      var result = CompileAndExecute("user.name = \"Jane\"; user.name", variables: variables);
+
+      Assert.Equal(Type.String, result.ValueType);
+      // Check in the variables container since assignment modifies the variable
+      Assert.Equal("Jane", result.Variables["user.name"].StringValue);
+    }
   }
 }

--- a/EpsilonScript/Lexer/Lexer.cs
+++ b/EpsilonScript/Lexer/Lexer.cs
@@ -39,7 +39,7 @@ namespace EpsilonScript.Lexer
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsIdentifierBody(char c)
     {
-      return IsIdentifierStart(c) || IsNumber(c);
+      return IsIdentifierStart(c) || IsNumber(c) || c == '.';
     }
 
     private bool Backup()

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -15,7 +15,7 @@ This document provides a specification for the EpsilonScript language.
 ### Identifiers and Keywords
 ```bnf
 <identifier_start> ::= <letter> | "_"
-<identifier_body>  ::= <identifier_start> | <digit>
+<identifier_body>  ::= <identifier_start> | <digit> | "."
 <identifier>       ::= <identifier_start> {<identifier_body>}
 
 <boolean_literal>  ::= "true" | "false"


### PR DESCRIPTION
Variable names and function names can now contain periods (e.g., `user.name`, `math.square()`)